### PR TITLE
Add instructions for custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ More on web renderers here: https://flutter.dev/docs/development/tools/web-rende
         with:
           webRenderer: canvaskit
 ```
+
+To use github pages with a custom domain, add a file named `CNAME` to the
+`<project>/web` folder whose contents is your domain, like:
+> subdomain.domain.com


### PR DESCRIPTION
Added instructions for when using a custom domain, as if you only set this in the repo settings the custom domain will be reset after every update - creating the CNAME manually allows it to persist. 😀