### PR TITLE
Add custom cmd args via --dart-define

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,6 @@ runs:
     - run: flutter pub get
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    # Placeholder for when this gets implemented. See https://github.com/flutter/flutter/pull/80519
-    #- run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} --dart-define=${{inputs.dartDefine}}
     - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --dart-define=${{inputs.dartDefine}}
       shell: bash
       working-directory: ${{inputs.workingDir}}

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,6 @@ inputs:
     description: 'The directory where the project is (default .)'
     required: false
     default: .
-#   baseHref:
-#     description: 'base-href i.e. / for root or /sub/ for subdirectory (add trailing /)'
-#     required: false
-#     default: /
   dartDefine:
     description: '--dart-define="TEST="custom-args" >> USE IN MAIN USING: >> const t = String.fromEnvironment("TEST"); >> RESULT: >> t = custom-args'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,14 @@ inputs:
     description: 'The directory where the project is (default .)'
     required: false
     default: .
-  baseHref:
-    description: 'base-href i.e. / for root or /sub/ for subdirectory (add trailing /)'
+#   baseHref:
+#     description: 'base-href i.e. / for root or /sub/ for subdirectory (add trailing /)'
+#     required: false
+#     default: /
+  dartDefine:
+    description: '--dart-define="TEST="custom-args" >> USE IN MAIN USING: >> const t = String.fromEnvironment("TEST"); >> RESULT: >> t = custom-args'
     required: false
-    default: /
+    default: ""
 
 runs:
   using: 'composite'
@@ -29,7 +33,9 @@ runs:
     - run: flutter pub get
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}}
+    # Placeholder for when this gets implemented. See https://github.com/flutter/flutter/pull/80519
+    #- run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} --dart-define=${{inputs.dartDefine}}
+    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --dart-define=${{inputs.dartDefine}}
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.name github-actions

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
     - run: flutter pub get
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.webRenderer}}
+    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}}
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.name github-actions

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'The directory where the project is (default .)'
     required: false
     default: .
+  baseHref:
+    description: 'base-href i.e. / for root or /sub/ for subdirectory (add trailing /)'
+    required: false
+    default: /
 
 runs:
   using: 'composite'
@@ -25,7 +29,7 @@ runs:
     - run: flutter pub get
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}}
+    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.webRenderer}}
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.name github-actions


### PR DESCRIPTION
Just tested this with a current WIP project (https://github.com/autonet-code/autonet-code/) via:

```
void main() async {
  // uses the command line arguments specified in the gh-actions file (.github/workflows/dart.yml)
  if (const String.fromEnvironment('hostDest') != 'githubPages') {
    setPathUrlStrategy();
  }

  runApp(const ProviderScope(child: MyApp()));
}
```

. . .Due to how gh-pages treats deep links in flutter without /#/.