### PR TITLE
Fix default dart-define bug introduced in v4 when not including an arg + change wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To pass arguments to the builder with `--dart-define` the `dartDefine` property 
 And consumed in the code via (**const** is mandatory!):
 ```dart
 void main() async {
-  String arg = const String.fromEnvironment('argKey'); // arg = "ArgVal"
+  String arg = const String.fromEnvironment('simple'); // arg = "example"
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2 # Only works with v2
       - uses: subosito/flutter-action@v1
-      - uses: erickzanardo/flutter-gh-pages@v5
+      - uses: erickzanardo/flutter-gh-pages@v6
 ```
 To build a project in a folder other that the root, use the `workingDir` property
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v5
+      - uses: erickzanardo/flutter-gh-pages@v6
         with:
           workingDir: example
 ```
@@ -37,7 +37,7 @@ More on web renderers here: https://flutter.dev/docs/development/tools/web-rende
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v5
+      - uses: erickzanardo/flutter-gh-pages@v6
         with:
           webRenderer: canvaskit
 ```
@@ -47,7 +47,7 @@ If you need to change that, the `targetBranch` property can be used
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v5
+      - uses: erickzanardo/flutter-gh-pages@v6
         with:
           targetBranch: my-gh-pages-branch
 ```
@@ -56,7 +56,7 @@ To pass arguments to the builder with `--dart-define` the `dartDefine` property 
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v5
+      - uses: erickzanardo/flutter-gh-pages@v6
         with:
           dartDefine: "customArg=TEST"
 ```

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ To pass arguments to the builder with `--dart-define` the `dartDefine` property 
       ...
       - uses: erickzanardo/flutter-gh-pages@v6
         with:
-          dartDefine: "customArg=TEST"
+          dartDefine: "argKey=argVal"
 ```
 
 
 And consumed in the code via (**const** is mandatory!):
 ```dart
 void main() async {
-  String arg = const String.fromEnvironment('customArg'); // arg = "TEST"
+  String arg = const String.fromEnvironment('argKey'); // arg = "ArgVal"
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ If you need to change that, the `targetBranch` property can be used
           targetBranch: my-gh-pages-branch
 ```
 
-To pass arguments to the builder with `--dart-define` the `dartDefine` property can be used
+To pass arguments to the builder with `--dart-define` the `customArgs` property can be used
 
 ```yml
       ...
       - uses: erickzanardo/flutter-gh-pages@v6
         with:
-          dartDefine: "argKey=argVal"
+          customArgs: --dart-define="simple=example"
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   dartDefine:
     description: 'Custom arg to be consumed in the app via --> var someArg = const String.fromEnvironment("argkey"); // someArg = argVal'
     required: false
-    default: "argKey=argVal"
+    default:
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,10 @@ inputs:
   targetBranch:
     required: false
     default: gh-pages
-  dartDefine:
-    description: 'Custom arg to be consumed in the app via --> var someArg = const String.fromEnvironment("argkey"); // someArg = argVal'
+  customArgs:
+    description: 'Custom args like: --dart-define="simple=example"'
     required: false
-    default: "argkey=argVal"
+    default:
 
 runs:
   using: 'composite'
@@ -32,7 +32,7 @@ runs:
     - run: flutter pub get
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --dart-define=${{inputs.dartDefine}}
+    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} ${{inputs.customArgs}}
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.name github-actions

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,9 @@ inputs:
     required: false
     default: gh-pages
   dartDefine:
-    description: '--dart-define="TEST="custom-args" >> USE IN MAIN USING: >> const t = String.fromEnvironment("TEST"); >> RESULT: >> t = custom-args'
+    description: '--dart-define="argkey=argval" >> USE IN MAIN WITH: >> final t = const String.fromEnvironment("argkey"); >> RESULT: >> t = argval'
     required: false
-    default: ""
+    default: "argkey=argval"
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   dartDefine:
     description: 'Custom arg to be consumed in the app via --> var someArg = const String.fromEnvironment("argkey"); // someArg = argVal'
     required: false
-    default: "argKey=argVal"
+    default: "="
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   dartDefine:
     description: 'Custom arg to be consumed in the app via --> var someArg = const String.fromEnvironment("argkey"); // someArg = argVal'
     required: false
-    default:
+    default: "argKey=argVal"
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   dartDefine:
     description: 'Custom arg to be consumed in the app via --> var someArg = const String.fromEnvironment("argkey"); // someArg = argVal'
     required: false
-    default: "="
+    default: "argkey=argVal"
 
 runs:
   using: 'composite'

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,9 @@ inputs:
     required: false
     default: gh-pages
   dartDefine:
-    description: '--dart-define="argkey=argval" >> USE IN MAIN WITH: >> final t = const String.fromEnvironment("argkey"); >> RESULT: >> t = argval'
+    description: 'Custom arg to be consumed in the app via --> var someArg = const String.fromEnvironment("argkey"); // someArg = argVal'
     required: false
-    default: "argkey=argval"
+    default: "argKey=argVal"
 
 runs:
   using: 'composite'


### PR DESCRIPTION
Neglected to test last commit in case of default value. For some reason it resulted in this error (https://github.com/Agondev/gh-feed/runs/3041513039?check_suite_focus=true):
```Error: Unknown option '-D'.```

Successful test w/ arg: https://github.com/Agondev/auto_net_web_client/actions/runs/996128057
Successful test w/o arg: https://github.com/Agondev/gh-feed/runs/3041643892