### PR TITLE
add baseHref

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2 # Only works with v2
       - uses: subosito/flutter-action@v1
-      - uses: erickzanardo/flutter-gh-pages@v6
+      - uses: erickzanardo/flutter-gh-pages@v7
 ```
 To build a project in a folder other that the root, use the `workingDir` property
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v6
+      - uses: erickzanardo/flutter-gh-pages@v7
         with:
           workingDir: example
 ```
@@ -37,7 +37,7 @@ More on web renderers here: https://flutter.dev/docs/development/tools/web-rende
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v6
+      - uses: erickzanardo/flutter-gh-pages@v7
         with:
           webRenderer: canvaskit
 ```
@@ -47,16 +47,26 @@ If you need to change that, the `targetBranch` property can be used
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v6
+      - uses: erickzanardo/flutter-gh-pages@v7
         with:
           targetBranch: my-gh-pages-branch
+```
+
+By default, the generated page only works on `User or Organization sites` ex:`user.github.io/`. 
+You can change that by specifying the `repoName`, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
+
+```yml
+      ...
+      - uses: erickzanardo/flutter-gh-pages@v7
+        with:
+          repoName: my-repo
 ```
 
 To pass arguments to the builder with `--dart-define` the `customArgs` property can be used
 
 ```yml
       ...
-      - uses: erickzanardo/flutter-gh-pages@v6
+      - uses: erickzanardo/flutter-gh-pages@v7
         with:
           customArgs: --dart-define="simple=example"
 ```

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ If you need to change that, the `targetBranch` property can be used
 ```
 
 By default, the generated page only works on `User or Organization sites` ex:`user.github.io/`. 
-You can change that by specifying the `repoName`, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
+You can change that by specifying the `baseHref`, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
 
 ```yml
       ...
       - uses: erickzanardo/flutter-gh-pages@v7
         with:
-          repoName: my-repo
+          baseHref: my-repo
 ```
 
 To pass arguments to the builder with `--dart-define` the `customArgs` property can be used

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you need to change that, the `targetBranch` property can be used
 ```
 
 By default, the generated page only works on `User or Organization sites` ex:`user.github.io/`. 
-You can change that by specifying the `baseHref`, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
+You can change that by specifying the `baseHref` argument, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
 The parameter `baseHref` must start and end with a forward slash `"/"`.
 (For projects created on flutter release version `2.2.3` or earlier, please manually edit the file `web/index.html`, changing the line `<base href="/">` to `<base href="$FLUTTER_BASE_HREF">`)
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ If you need to change that, the `targetBranch` property can be used
 
 By default, the generated page only works on `User or Organization sites` ex:`user.github.io/`. 
 You can change that by specifying the `baseHref`, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
+(For projects created on flutter release version `2.2.3` or earlier, please manually edit the file `web/index.html`, changing the line `<base href="/">` to `<base href="$FLUTTER_BASE_HREF">`)
 
 ```yml
       ...
       - uses: erickzanardo/flutter-gh-pages@v7
         with:
-          baseHref: my-repo
+          baseHref: /my-repo/
 ```
 
 To pass arguments to the builder with `--dart-define` the `customArgs` property can be used

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If you need to change that, the `targetBranch` property can be used
 
 By default, the generated page only works on `User or Organization sites` ex:`user.github.io/`. 
 You can change that by specifying the `baseHref`, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
+The parameter `baseHref` must start and end with a forward slash `"/"`.
 (For projects created on flutter release version `2.2.3` or earlier, please manually edit the file `web/index.html`, changing the line `<base href="/">` to `<base href="$FLUTTER_BASE_HREF">`)
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If you need to change that, the `targetBranch` property can be used
 
 By default, the generated page only works on `User or Organization sites` ex:`user.github.io/`. 
 You can change that by specifying the `baseHref` argument, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
+
 The parameter `baseHref` must start and end with a forward slash `"/"`.
 (For projects created on flutter release version `2.2.3` or earlier, please manually edit the file `web/index.html`, changing the line `<base href="/">` to `<base href="$FLUTTER_BASE_HREF">`)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ By default, the generated page only works on `User or Organization sites` ex:`us
 You can change that by specifying the `baseHref` argument, so the site will work on a `Project Site`, ex:`user.github.io/repoName`.
 
 The parameter `baseHref` must start and end with a forward slash `"/"`.
-(For projects created on flutter release version `2.2.3` or earlier, please manually edit the file `web/index.html`, changing the line `<base href="/">` to `<base href="$FLUTTER_BASE_HREF">`)
+(For projects created on flutter version earlier than `2.5.0`, please manually edit the file `web/index.html`, changing the line `<base href="/">` to `<base href="$FLUTTER_BASE_HREF">`)
 
 ```yml
       ...

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ inputs:
   targetBranch:
     required: false
     default: gh-pages
-  repoName:
-    description: 'Name of the Project Site repositoy (if applicable)'
+  baseHref:
+    description: 'base href (if applicable)'
     required: false
     default: "/"
   customArgs:
@@ -36,19 +36,13 @@ runs:
     - run: flutter pub get
       shell: bash
       working-directory: ${{inputs.workingDir}}
-    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} ${{inputs.customArgs}}
+    - run: flutter build web --release --web-renderer=${{inputs.webRenderer}} --base-href ${{inputs.baseHref}} ${{inputs.customArgs}}
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.name github-actions
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.email github-actions@github.com
-      shell: bash
-      working-directory: ${{inputs.workingDir}}
-    - run: >
-        if [ "${{inputs.repoName}}" != "/" ]; then
-          sed -e 's+<base href="/">+<base href="/${{inputs.repoName}}/">+' -i 'build/web/index.html'
-        fi
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git --work-tree build/web add --all

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: gh-pages
   repoName:
-    description: 'Name of the Project Site repositoy (if aplicable)'
+    description: 'Name of the Project Site repositoy (if applicable)'
     required: false
     default: "/"
   customArgs:

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   targetBranch:
     required: false
     default: gh-pages
+  repoName:
+    description: 'Name of the Project Site repositoy (if aplicable)'
+    required: false
+    default: "/"
   customArgs:
     description: 'Custom args like: --dart-define="simple=example"'
     required: false
@@ -39,6 +43,12 @@ runs:
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git config user.email github-actions@github.com
+      shell: bash
+      working-directory: ${{inputs.workingDir}}
+    - run: >
+        if [ "${{inputs.repoName}}" != "/" ]; then
+          sed -e 's+<base href="/">+<base href="/${{inputs.repoName}}/">+' -i 'build/web/index.html'
+        fi
       shell: bash
       working-directory: ${{inputs.workingDir}}
     - run: git --work-tree build/web add --all


### PR DESCRIPTION
Allow publishing to a github page that's not named after the user/institution. ex: user.github.io/repoName